### PR TITLE
Run dartfmt --fix

### DIFF
--- a/lib/multi_server_socket.dart
+++ b/lib/multi_server_socket.dart
@@ -52,7 +52,7 @@ class MultiServerSocket extends StreamView<Socket> implements ServerSocket {
   ///
   /// See [ServerSocket.bind].
   static Future<ServerSocket> loopback(int port,
-      {int backlog, bool v6Only: false, bool shared: false}) {
+      {int backlog, bool v6Only = false, bool shared = false}) {
     backlog ??= 0;
 
     return _loopback(port, 5, backlog, v6Only, shared);
@@ -76,7 +76,7 @@ class MultiServerSocket extends StreamView<Socket> implements ServerSocket {
       var v6Server = await ServerSocket.bind(
           InternetAddress.loopbackIPv6, v4Server.port,
           backlog: backlog, v6Only: v6Only, shared: shared);
-      return new MultiServerSocket([v4Server, v6Server]);
+      return MultiServerSocket([v4Server, v6Server]);
     } on SocketException catch (error) {
       if (error.osError.errorCode != _addressInUseErrno) rethrow;
       if (port != 0) rethrow;

--- a/test/multi_server_socket_test.dart
+++ b/test/multi_server_socket_test.dart
@@ -20,7 +20,7 @@ void main() {
       subServer1 = await ServerSocket.bind("127.0.0.1", 0);
       subServer2 = await ServerSocket.bind("127.0.0.1", 0);
       subServer3 = await ServerSocket.bind("127.0.0.1", 0);
-      multiServer = new MultiServerSocket([subServer1, subServer2, subServer3]);
+      multiServer = MultiServerSocket([subServer1, subServer2, subServer3]);
     });
 
     tearDown(() => multiServer.close());
@@ -42,12 +42,12 @@ void main() {
     test("close closes all servers", () async {
       await multiServer.close();
 
-      expect(() => _connect(subServer1),
-          throwsA(new TypeMatcher<SocketException>()));
-      expect(() => _connect(subServer2),
-          throwsA(new TypeMatcher<SocketException>()));
-      expect(() => _connect(subServer3),
-          throwsA(new TypeMatcher<SocketException>()));
+      expect(
+          () => _connect(subServer1), throwsA(TypeMatcher<SocketException>()));
+      expect(
+          () => _connect(subServer2), throwsA(TypeMatcher<SocketException>()));
+      expect(
+          () => _connect(subServer3), throwsA(TypeMatcher<SocketException>()));
     });
   });
 


### PR DESCRIPTION
Drop optional new, use `=` for named argument defaults.

The relevant lints will be enabled when we enforce `package:pedantic`.