### PR TITLE
Enforce pedantic lints

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,6 @@
+include: package:pedantic/analysis_options.yaml
+analyzer:
+  strong-mode:
+    implicit-casts: false
+  language:
+    strict-raw-types: true

--- a/lib/multi_server_socket.dart
+++ b/lib/multi_server_socket.dart
@@ -32,12 +32,14 @@ class MultiServerSocket extends StreamView<Socket> implements ServerSocket {
   ///
   /// If the wrapped servers are listening on different ports, it's not defined
   /// which port is returned.
+  @override
   int get port => _servers.first.port;
 
   /// Returns the address that one of the wrapped servers is listening on.
   ///
   /// If the wrapped servers are listening on different addresses, it's not
   /// defined which address is returned.
+  @override
   InternetAddress get address => _servers.first.address;
 
   /// Creates a [MultiServerSocket] wrapping [servers].
@@ -85,12 +87,13 @@ class MultiServerSocket extends StreamView<Socket> implements ServerSocket {
       // A port being available on IPv4 doesn't necessarily mean that the same
       // port is available on IPv6. If it's not (which is rare in practice),
       // we try again until we find one that's available on both.
-      v4Server.close();
+      unawaited(v4Server.close());
       return await _loopback(
           port, remainingRetries - 1, backlog, v6Only, shared);
     }
   }
 
+  @override
   Future<ServerSocket> close() =>
       Future.wait(_servers.map((server) => server.close())).then((_) => this);
 }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -27,4 +27,5 @@ final Future<bool> supportsIPv4 = () async {
   }
 }();
 
+// Avoids a normal dependencies on `package:pedantic`.
 void unawaited(Future<void> f) {}

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -9,7 +9,7 @@ import 'dart:io';
 final Future<bool> supportsIPv6 = () async {
   try {
     var socket = await ServerSocket.bind(InternetAddress.loopbackIPv6, 0);
-    socket.close();
+    unawaited(socket.close());
     return true;
   } on SocketException catch (_) {
     return false;
@@ -20,9 +20,11 @@ final Future<bool> supportsIPv6 = () async {
 final Future<bool> supportsIPv4 = () async {
   try {
     var socket = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
-    socket.close();
+    unawaited(socket.close());
     return true;
   } on SocketException catch (_) {
     return false;
   }
 }();
+
+void unawaited(Future<void> f) {}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,3 +12,4 @@ dependencies:
 
 dev_dependencies:
   test: ^1.3.0
+  pedantic: ^1.0.0

--- a/test/multi_server_socket_test.dart
+++ b/test/multi_server_socket_test.dart
@@ -11,21 +11,21 @@ import 'package:multi_server_socket/src/utils.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group("with multiple ServerSockets", () {
+  group('with multiple ServerSockets', () {
     ServerSocket multiServer;
     ServerSocket subServer1;
     ServerSocket subServer2;
     ServerSocket subServer3;
     setUp(() async {
-      subServer1 = await ServerSocket.bind("127.0.0.1", 0);
-      subServer2 = await ServerSocket.bind("127.0.0.1", 0);
-      subServer3 = await ServerSocket.bind("127.0.0.1", 0);
+      subServer1 = await ServerSocket.bind('127.0.0.1', 0);
+      subServer2 = await ServerSocket.bind('127.0.0.1', 0);
+      subServer3 = await ServerSocket.bind('127.0.0.1', 0);
       multiServer = MultiServerSocket([subServer1, subServer2, subServer3]);
     });
 
     tearDown(() => multiServer.close());
 
-    test("listen listens to all servers", () async {
+    test('listen listens to all servers', () async {
       multiServer.listen((socket) {
         socket.add([1, 2, 3, 4]);
         socket.close();
@@ -39,7 +39,7 @@ void main() {
           (await _connect(subServer3)).first, completion(equals([1, 2, 3, 4])));
     });
 
-    test("close closes all servers", () async {
+    test('close closes all servers', () async {
       await multiServer.close();
 
       expect(
@@ -51,7 +51,7 @@ void main() {
     });
   });
 
-  group("MultiServerSocket.loopback", () {
+  group('MultiServerSocket.loopback', () {
     ServerSocket server;
     setUp(() async {
       server = await MultiServerSocket.loopback(0);
@@ -59,7 +59,7 @@ void main() {
 
     tearDown(() => server.close());
 
-    test("listens on all localhost interfaces", () async {
+    test('listens on all localhost interfaces', () async {
       server.listen((socket) {
         socket.add([1, 2, 3, 4]);
         socket.close();


### PR DESCRIPTION
Fix violations of:
- annotate_overrides
- prefer_single_quotes
- unawaited_futures

Disable implicit casts and enable strict raw types. These were already
clean.

Drop a small `unawaited` utility in this package rather than use the one
in `package:pedantic` to keep transitive deps minimal.