### PR TITLE
Tweak doc comments

### DIFF
--- a/lib/multi_server_socket.dart
+++ b/lib/multi_server_socket.dart
@@ -28,13 +28,13 @@ class MultiServerSocket extends StreamView<Socket> implements ServerSocket {
   /// The wrapped servers.
   final Set<ServerSocket> _servers;
 
-  /// Returns the port that one of the wrapped servers is listening on.
+  /// The port that one of the wrapped servers is listening on.
   ///
   /// If the wrapped servers are listening on different ports, it's not defined
   /// which port is returned.
   int get port => _servers.first.port;
 
-  /// Returns the address that one of the wrapped servers is listening on.
+  /// The address that one of the wrapped servers is listening on.
   ///
   /// If the wrapped servers are listening on different addresses, it's not
   /// defined which address is returned.
@@ -58,7 +58,6 @@ class MultiServerSocket extends StreamView<Socket> implements ServerSocket {
     return _loopback(port, 5, backlog, v6Only, shared);
   }
 
-  /// A helper method for initializing loopback servers.
   static Future<ServerSocket> _loopback(int port, int remainingRetries,
       int backlog, bool v6Only, bool shared) async {
     if (!await supportsIPv4) {

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:io';
 
-/// Returns whether this computer supports binding to IPv6 addresses.
+/// Whether this computer supports binding to IPv6 addresses.
 final Future<bool> supportsIPv6 = () async {
   try {
     var socket = await ServerSocket.bind(InternetAddress.loopbackIPv6, 0);
@@ -16,7 +16,7 @@ final Future<bool> supportsIPv6 = () async {
   }
 }();
 
-/// Returns whether this computer supports binding to IPv4 addresses.
+/// Whether this computer supports binding to IPv4 addresses.
 final Future<bool> supportsIPv4 = () async {
   try {
     var socket = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);


### PR DESCRIPTION
Drop a comment on a private member which states the obvious.

Rephrase comments on variables and getters to use noun phrases.